### PR TITLE
Fix broken URL in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 default:
 	mkdir -p examples/jars
-	wget -O examples/jars/sansa-examples-spark.jar https://github.com/SANSA-Stack/SANSA-Examples/releases/download/develop/sansa-examples-spark_2.11-develop.jar
+	wget -O examples/jars/sansa-examples-spark.jar https://github.com/SANSA-Stack/SANSA-Examples/releases/download/v2017-12/sansa-examples-spark_2.11-2017-12.jar
 
 load-data:
 	docker run -it --rm -v $(shell pwd)/examples/data:/data --net spark-net -e "CORE_CONF_fs_defaultFS=hdfs://namenode:8020" bde2020/hadoop-namenode:1.1.0-hadoop2.8-java8 hdfs dfs -copyFromLocal /data /data


### PR DESCRIPTION
The old URL pointing to SANSA Examples in the Makefile was broken and the project wouldn't build. I changed it for the latest release.