### PR TITLE
Give permission to execute scripts

### DIFF
--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -3,6 +3,8 @@ FROM bde2020/spark-submit:2.1.0-hadoop2.8-hive-java8
 COPY jars /jars
 COPY data /data
 
+RUN chmod +x /wait-for-step.sh && chmod +x /execute-step.sh && chmod +x /finish-step.sh
+
 ENV SPARK_MASTER_NAME spark-master
 ENV SPARK_MASTER_PORT 7077
 ENV SPARK_APPLICATION_JAR_LOCATION /jars/sansa-examples-spark.jar


### PR DESCRIPTION
However, this should probably be tackled in the original image (spark-base): https://hub.docker.com/r/bde2020/spark-base/~/dockerfile/